### PR TITLE
Fix reference lost when creating an agent

### DIFF
--- a/faust_bootstrap/core/app/app_faust.py
+++ b/faust_bootstrap/core/app/app_faust.py
@@ -40,7 +40,7 @@ class FaustApplication(ABC):
         self._cli = FaustCli()
 
     def create_agent(self, agent_function: AgentFun[Callable], channel: Union[str, ChannelT] = None, **kwargs):
-        self.app.agent(channel, **kwargs)(agent_function)
+        return self.app.agent(channel, **kwargs)(agent_function)
 
     def register_parameter(self, name: str, required: bool, help: str, type: Any, **kwargs):
         self._cli.add_option(name, required, help, type, **kwargs)


### PR DESCRIPTION
This fix the problem when you create and agent and you want the reference of that agent. With this fix you avoid to search the agent inside the faust app.